### PR TITLE
Use relative paths for rclone symlinks

### DIFF
--- a/backend/WebDav/DatabaseStoreSymlinkCollection.cs
+++ b/backend/WebDav/DatabaseStoreSymlinkCollection.cs
@@ -108,9 +108,9 @@ public class DatabaseStoreSymlinkCollection(
             DavItem.ItemType.Directory =>
                 new DatabaseStoreSymlinkCollection(davItem, dbClient, configManager, RelativePath),
             DavItem.ItemType.NzbFile =>
-                new DatabaseStoreSymlinkFile(davItem, RelativePath, configManager),
+                new DatabaseStoreSymlinkFile(davItem, RelativePath),
             DavItem.ItemType.RarFile =>
-                new DatabaseStoreSymlinkFile(davItem, RelativePath, configManager),
+                new DatabaseStoreSymlinkFile(davItem, RelativePath),
             _ => throw new ArgumentException("Unrecognized directory child type.")
         };
     }

--- a/backend/WebDav/DatabaseStoreSymlinkFile.cs
+++ b/backend/WebDav/DatabaseStoreSymlinkFile.cs
@@ -1,7 +1,6 @@
-﻿using System.Text;
+using System.Text;
 using NWebDav.Server;
 using NWebDav.Server.Stores;
-using NzbWebDAV.Config;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Utils;
 using NzbWebDAV.WebDav.Base;
@@ -10,14 +9,16 @@ using Serilog;
 
 namespace NzbWebDAV.WebDav;
 
-public class DatabaseStoreSymlinkFile(DavItem davFile, string parentPath, ConfigManager configManager) : BaseStoreItem
+public class DatabaseStoreSymlinkFile(DavItem davFile, string parentPath) : BaseStoreItem
 {
     public override string Name => davFile.Name + ".rclonelink";
     public override string UniqueKey => davFile.Id + ".rclonelink";
     public override long FileSize => ContentBytes.Length;
 
     private string TargetPath =>
-        Path.Combine(configManager.GetRcloneMountDir(), DavItem.ContentFolder.Name, parentPath, davFile.Name);
+        Path
+            .Combine("..", "..", DavItem.ContentFolder.Name, parentPath, davFile.Name)
+            .Replace('\\', '/');
 
     private byte[] ContentBytes =>
         Encoding.UTF8.GetBytes(TargetPath);


### PR DESCRIPTION
## Summary
- build symlink target using `Path.Combine("..", "..", ...)` and forward slashes
- remove unused ConfigManager from DatabaseStoreSymlinkFile and update callers

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_b_6892aba23ec88321bab2aba4f775f6f0