### PR TITLE
fix: generate dynamic symlink target paths

### DIFF
--- a/backend/WebDav/DatabaseStoreSymlinkFile.cs
+++ b/backend/WebDav/DatabaseStoreSymlinkFile.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Text;
 using NWebDav.Server;
 using NWebDav.Server.Stores;
@@ -15,10 +16,21 @@ public class DatabaseStoreSymlinkFile(DavItem davFile, string parentPath) : Base
     public override string UniqueKey => davFile.Id + ".rclonelink";
     public override long FileSize => ContentBytes.Length;
 
-    private string TargetPath =>
-        Path
-            .Combine("..", "..", DavItem.ContentFolder.Name, parentPath, davFile.Name)
-            .Replace('\\', '/');
+    private string TargetPath
+    {
+        get
+        {
+            var ups = Enumerable.Repeat(
+                "..",
+                parentPath.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries).Length + 1
+            );
+
+            return Path.Combine(
+                    ups.Concat(new[] { DavItem.ContentFolder.Name, parentPath, davFile.Name }).ToArray()
+                )
+                .Replace('\\', '/');
+        }
+    }
 
     private byte[] ContentBytes =>
         Encoding.UTF8.GetBytes(TargetPath);


### PR DESCRIPTION
## Summary
- compute symlink target paths relative to parent depth

## Testing
- `~/.dotnet/dotnet build`
- `~/.dotnet/dotnet test`

------
https://chatgpt.com/codex/tasks/task_b_689347b9d06c8321926f636854cf6124