### PR TITLE
Fix subject filename parsing regexes

### DIFF
--- a/backend/Extensions/NzbFileExtensions.cs
+++ b/backend/Extensions/NzbFileExtensions.cs
@@ -26,7 +26,7 @@ public static class NzbFileExtensions
     private static string TryParseFilename1(this NzbFile file)
     {
         // example: `[1/8] - "file.mkv" yEnc 12345 (1/54321)`
-        var match = Regex.Match(file.Subject, "\\\"(.*)\\\"");
+        var match = Regex.Match(file.Subject, @"""(.*)""");
         if (match.Success) return match.Groups[1].Value;
         return "";
     }
@@ -34,11 +34,11 @@ public static class NzbFileExtensions
     private static string TryParseFilename2(this NzbFile file)
     {
         // example: `Some release [file.mkv] [release]`
-        var matches = Regex.Matches(file.Subject, @"\[([^\[\]]*)\]");
-        return matches
-            .Select(x => x.Groups[1].Value)
-            .Where(x => Path.GetExtension(x).StartsWith("."))
-            .FirstOrDefault(x => Path.GetExtension(x).Length < 6) ?? "";
+        var match = Regex.Match(
+            file.Subject,
+            @"\b([\w\-+()' .,]+(?:\[[\w\-\/+()' .,]*][\w\-+()' .,]*)*\.[A-Za-z0-9]{2,4})\b"
+        );
+        return match.Success ? match.Groups[1].Value : "";
     }
 
     private static string TryParseFilename3(this NzbFile file)
@@ -58,7 +58,7 @@ public static class NzbFileExtensions
         if (Regex.IsMatch(file.Subject, @"\(\d+/\d+\)")) return "";
         var match = Regex.Match(
             file.Subject,
-            @"([^\s\"]+\.(?:mkv|mp4|avi|wmv|mov|m4v|mpg|mpeg|ts|m2ts|flv))",
+            "([^\\s\"]+\\.(?:mkv|mp4|avi|wmv|mov|m4v|mpg|mpeg|ts|m2ts|flv))",
             RegexOptions.IgnoreCase
         );
         return match.Success ? match.Groups[1].Value : "";


### PR DESCRIPTION
## Summary
- update TryParseFilename1 to use verbatim regex pattern
- revise TryParseFilename2 to match subject filenames with a single regex
- correct regex string in TryParseFilename4

## Testing
- `~/.dotnet/dotnet build backend/NzbWebDAV.csproj`

------
https://chatgpt.com/codex/tasks/task_b_6895d623876483218e402958f083977e