### PR TITLE
Add global connections-per-stream setting for Usenet providers

### DIFF
--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -14,7 +14,8 @@ function isProvidersSettingsUpdated(config: Record<string, string>, newConfig: R
     // Check if provider count changed
     if (config["usenet.providers.count"] !== newConfig["usenet.providers.count"]) return true;
     if (config["usenet.providers.primary"] !== newConfig["usenet.providers.primary"]) return true;
-    
+    if (config["usenet.connections-per-stream"] !== newConfig["usenet.connections-per-stream"]) return true;
+
     // Check all provider-specific keys
     const allKeys = Object.keys(newConfig);
     const providerKeys = allKeys.filter(key => key.startsWith("usenet.provider."));


### PR DESCRIPTION
## Summary
- Add configurable "Connections Per Stream" field on Usenet Providers screen
- Validate connections per stream against provider max connections and positive integers
- Track connections-per-stream changes in settings save flow

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68968aa749408321897459d35b2dc2cc