### PR TITLE
Honor per-provider NNTP connection limits

### DIFF
--- a/frontend/app/routes/settings.update/route.tsx
+++ b/frontend/app/routes/settings.update/route.tsx
@@ -12,13 +12,13 @@ export async function action({ request }: Route.ActionArgs) {
     // get the ConfigItems to update
     const formData = await request.formData();
     const configJson = formData.get("config")!.toString();
-    const config = JSON.parse(configJson);
+    const config = JSON.parse(configJson) as Record<string, unknown>;
     const configItems: ConfigItem[] = [];
-    for (const [key, value] of Object.entries<string>(config)) {
+    for (const [key, value] of Object.entries(config)) {
         configItems.push({
             configName: key,
-            configValue: value
-        })
+            configValue: String(value)
+        });
     }
 
     // update the config items

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -199,8 +199,10 @@ function getChangedConfig(
     // Check changes in provider-specific keys
     const allKeys = new Set([...Object.keys(config), ...Object.keys(newConfig)]);
     for (const key of allKeys) {
-        if (key.startsWith("usenet.provider.") && config[key] !== newConfig[key]) {
-            changedConfig[key] = newConfig[key];
+        if (key.startsWith("usenet.provider.")) {
+            if (key.endsWith(".connections") || config[key] !== newConfig[key]) {
+                changedConfig[key] = newConfig[key];
+            }
         }
     }
     


### PR DESCRIPTION
## Summary
- validate provider connections without falling back to 10 and always send their values
- forward connection counts through settings update route
- use per-provider connection limits in UsenetStreamingClient

## Testing
- `npm run typecheck`
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_b_68969b43f4c48321af8146b2e207b159