### PR TITLE
feat: add configurable symlink mirror directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,19 @@ To try it out, run the following command to pull and run the image with port `30
 docker run --rm -it -p 3000:3000 ghcr.io/nzbdav-dev/nzbdav:pre-alpha
 ```
 
-And if you would like to persist saved settings, attach a volume at `/config`
+And if you would like to persist saved settings, attach a volume at `/config` and bind-mount a folder for generated symlinks at `/completed-symlinks`.
 
 ```
-mkdir -p $(pwd)/nzbdav && \
+mkdir -p $(pwd)/nzbdav $(pwd)/completed-symlinks && \
 docker run --rm -it \
   -v $(pwd)/nzbdav:/config \
+  -v $(pwd)/completed-symlinks:/completed-symlinks \
   -e PUID=1000 \
   -e PGID=1000 \
   -p 3000:3000 \
   ghcr.io/nzbdav-dev/nzbdav:pre-alpha
 ```
+By default, symlinks are written to `/completed-symlinks`. You can change this inside the container by setting the `SYMLINK_MIRROR_DIR` environment variable and updating the volume mount accordingly.
 After starting the container, be sure to navigate to the Settings page on the UI to finish setting up your usenet connection settings.
 
 <p align="center">
@@ -102,8 +104,8 @@ Once you have the webdav mounted onto your filesystem (e.g. accessible at `/mnt/
 * Radar will send an *.nzb to NZB-Dav to "download"
 * NZB-Dav will mount the nzb onto the webdav without actually downloading it.
 * RClone will make the nzb contents available to your filesystem by streaming, without using any storage space on your server.
-* NZB-Dav will tell Radarr that the "download" has completed within the `/mnt/nzbdav/completed-symlinks` folder.
-* Radarr will grab the symlinks from `/mnt/nzbdav/completed-symlinks` and will move them to wherever you have your media library.
+* NZB-Dav will tell Radarr that the "download" has completed within the `/completed-symlinks` folder (or your custom `SYMLINK_MIRROR_DIR`).
+* Radarr will grab the symlinks from this folder and will move them to wherever you have your media library.
 * The symlinks always point to the `/mnt/nzbdav/completed` folder which contain the streamable content.
 * Plex accesses one of the symlinks from your media library, it will automatically fetch and stream it from the mounted webdav.
 

--- a/backend/Api/SabControllers/GetConfig/GetConfigController.cs
+++ b/backend/Api/SabControllers/GetConfig/GetConfigController.cs
@@ -24,7 +24,7 @@ public class GetConfigController(
         var root = JsonNode.Parse(config)!;
 
         // update the complete_dir
-        var completeDir = Path.Join(configManager.GetRcloneMountDir(), DavItem.SymlinkFolder.Name);
+        var completeDir = configManager.GetSymlinkMirrorDir();
         root["config"]!["misc"]!["complete_dir"] = completeDir;
 
         // update the categories

--- a/backend/Api/SabControllers/GetFullStatus/GetFullStatusController.cs
+++ b/backend/Api/SabControllers/GetFullStatus/GetFullStatusController.cs
@@ -17,7 +17,7 @@ public class GetFullStatusController(
         {
             Status = new GetFullStatusResponse.FullStatusObject()
             {
-                CompleteDir = Path.Join(configManager.GetRcloneMountDir(), DavItem.SymlinkFolder.Name),
+                CompleteDir = configManager.GetSymlinkMirrorDir(),
             }
         };
 

--- a/backend/Api/SabControllers/GetHistory/GetHistoryController.cs
+++ b/backend/Api/SabControllers/GetHistory/GetHistoryController.cs
@@ -36,8 +36,7 @@ public class GetHistoryController(
                 SizeInBytes = historyItem.TotalSegmentBytes,
                 DownloadPath = Path.Join(new[]
                 {
-                    configManager.GetRcloneMountDir(),
-                    DavItem.SymlinkFolder.Name,
+                    configManager.GetSymlinkMirrorDir(),
                     historyItem.Category,
                     historyItem.JobName
                 }),

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -56,6 +56,13 @@ public class ConfigManager
                ?? "/tmp";
     }
 
+    public string GetSymlinkMirrorDir()
+    {
+        return StringUtil.EmptyToNull(GetConfigValue("symlink.mirror-dir"))
+               ?? StringUtil.EmptyToNull(Environment.GetEnvironmentVariable("SYMLINK_MIRROR_DIR"))
+               ?? "/completed-symlinks";
+    }
+
     public string GetApiKey()
     {
         return StringUtil.EmptyToNull(GetConfigValue("api.key"))

--- a/backend/WebDav/DatabaseStoreCollection.cs
+++ b/backend/WebDav/DatabaseStoreCollection.cs
@@ -100,7 +100,7 @@ public class DatabaseStoreCollection(
             DavItem.ItemType.Directory =>
                 new DatabaseStoreCollection(davItem, dbClient, configManager, usenetClient, queueManager),
             DavItem.ItemType.SymlinkRoot =>
-                new DatabaseStoreSymlinkCollection(davItem, dbClient),
+                new DatabaseStoreSymlinkCollection(davItem, dbClient, configManager),
             DavItem.ItemType.NzbFile =>
                 new DatabaseStoreNzbFile(davItem, dbClient, usenetClient, configManager),
             DavItem.ItemType.RarFile =>

--- a/backend/WebDav/DatabaseStoreSymlinkCollection.cs
+++ b/backend/WebDav/DatabaseStoreSymlinkCollection.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.RegularExpressions;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Caching.Memory;
 using NWebDav.Server;
 using NWebDav.Server.Stores;
@@ -6,20 +6,46 @@ using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.WebDav.Base;
 using NzbWebDAV.WebDav.Requests;
+using NzbWebDAV.Config;
+using System.IO;
+using System.Linq;
 
 namespace NzbWebDAV.WebDav;
 
-public class DatabaseStoreSymlinkCollection(
-    DavItem davDirectory,
-    DavDatabaseClient dbClient,
-    string parentPath = ""
-) : BaseStoreCollection
+public class DatabaseStoreSymlinkCollection : BaseStoreCollection
 {
+    private readonly DavItem davDirectory;
+    private readonly DavDatabaseClient dbClient;
+    private readonly ConfigManager configManager;
+    private readonly string parentPath;
+
+    public DatabaseStoreSymlinkCollection(
+        DavItem davDirectory,
+        DavDatabaseClient dbClient,
+        ConfigManager configManager,
+        string parentPath = ""
+    )
+    {
+        this.davDirectory = davDirectory;
+        this.dbClient = dbClient;
+        this.configManager = configManager;
+        this.parentPath = parentPath;
+
+        if (davDirectory.Id == DavItem.SymlinkFolder.Id && string.IsNullOrEmpty(parentPath))
+        {
+            foreach (var folder in new[] { "movies", "tv", "uncategorized" })
+            {
+                Directory.CreateDirectory(Path.Join(MirrorRoot, folder));
+            }
+        }
+    }
+
     public override string Name => davDirectory.Name;
     public override string UniqueKey => davDirectory.Id.ToString();
 
     private string RelativePath => davDirectory.Id == DavItem.SymlinkFolder.Id ? "" : Path.Join(parentPath, Name);
     private Guid TargetId => davDirectory.Id == DavItem.SymlinkFolder.Id ? DavItem.ContentFolder.Id : davDirectory.Id;
+    private string MirrorRoot => configManager.GetSymlinkMirrorDir();
     private DeletedFileManager DeletedFiles => new(davDirectory.Id);
 
     protected override Task<StoreItemResult> CopyAsync(CopyRequest request)
@@ -40,7 +66,7 @@ public class DatabaseStoreSymlinkCollection(
     {
         return (await dbClient.GetDirectoryChildrenAsync(TargetId, cancellationToken))
             .Select(GetItem)
-            .Where(x => !DeletedFiles.IsDeleted(x.Name)) // must appear after Select(GetItem) for correct Name.
+            .Where(x => !DeletedFiles.IsDeleted(x.Name))
             .ToArray();
     }
 
@@ -101,10 +127,11 @@ public class DatabaseStoreSymlinkCollection(
 
     private IStoreItem GetItem(DavItem davItem)
     {
+        EnsureMirror(davItem);
         return davItem.Type switch
         {
             DavItem.ItemType.Directory =>
-                new DatabaseStoreSymlinkCollection(davItem, dbClient, RelativePath),
+                new DatabaseStoreSymlinkCollection(davItem, dbClient, configManager, RelativePath),
             DavItem.ItemType.NzbFile =>
                 new DatabaseStoreSymlinkFile(davItem, RelativePath),
             DavItem.ItemType.RarFile =>
@@ -113,9 +140,32 @@ public class DatabaseStoreSymlinkCollection(
         };
     }
 
-    private class DeletedFileManager(Guid directoryId)
+    private void EnsureMirror(DavItem item)
+    {
+        var relative = Path.Join(parentPath, item.Name);
+        if (item.Type == DavItem.ItemType.Directory || item.Type == DavItem.ItemType.SymlinkRoot)
+        {
+            Directory.CreateDirectory(Path.Join(MirrorRoot, relative));
+            return;
+        }
+
+        var dir = Path.Join(MirrorRoot, parentPath);
+        Directory.CreateDirectory(dir);
+        var filePath = Path.Join(dir, item.Name + ".rclonelink");
+        var ups = Enumerable.Repeat("..", parentPath.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries).Length + 1);
+        var target = Path.Combine(ups.Concat(new[] { DavItem.ContentFolder.Name, parentPath, item.Name }).ToArray()).Replace('\\', '/');
+        File.WriteAllText(filePath, target);
+    }
+
+    private class DeletedFileManager
     {
         private static readonly MemoryCache DeletedFiles = new(new MemoryCacheOptions());
+        private readonly Guid directoryId;
+
+        public DeletedFileManager(Guid directoryId)
+        {
+            this.directoryId = directoryId;
+        }
 
         public void AddDeletedFile(string filename, TimeSpan? expiry = null)
         {


### PR DESCRIPTION
## Summary
- allow overriding symlink mirror dir via `SYMLINK_MIRROR_DIR`
- materialize symlink mirror with movie/tv/uncategorized subfolders
- document bind-mounting `/completed-symlinks`

## Testing
- `dotnet build backend/NzbWebDAV.csproj`
- `npm test` *(fails: Missing script "test" )*


------
https://chatgpt.com/codex/tasks/task_b_689891ae17dc83218b71b811e6770698