### PR TITLE
Use RelativePath for symlink mirror paths

### DIFF
--- a/backend/WebDav/DatabaseStoreSymlinkCollection.cs
+++ b/backend/WebDav/DatabaseStoreSymlinkCollection.cs
@@ -142,18 +142,17 @@ public class DatabaseStoreSymlinkCollection : BaseStoreCollection
 
     private void EnsureMirror(DavItem item)
     {
-        var relative = Path.Join(parentPath, item.Name);
         if (item.Type == DavItem.ItemType.Directory || item.Type == DavItem.ItemType.SymlinkRoot)
         {
-            Directory.CreateDirectory(Path.Join(MirrorRoot, relative));
+            Directory.CreateDirectory(Path.Join(MirrorRoot, RelativePath, item.Name));
             return;
         }
 
-        var dir = Path.Join(MirrorRoot, parentPath);
+        var dir = Path.Join(MirrorRoot, RelativePath);
         Directory.CreateDirectory(dir);
         var filePath = Path.Join(dir, item.Name + ".rclonelink");
-        var ups = Enumerable.Repeat("..", parentPath.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries).Length + 1);
-        var target = Path.Combine(ups.Concat(new[] { DavItem.ContentFolder.Name, parentPath, item.Name }).ToArray()).Replace('\\', '/');
+        var ups = Enumerable.Repeat("..", RelativePath.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries).Length + 1);
+        var target = Path.Combine(ups.Concat(new[] { DavItem.ContentFolder.Name, RelativePath, item.Name }).ToArray()).Replace('\\', '/');
         File.WriteAllText(filePath, target);
     }
 


### PR DESCRIPTION
## Summary
- use RelativePath instead of parentPath when building mirror directories and rclone link files

## Testing
- `dotnet test backend` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- Manually ran a console harness to confirm movies, tv, and uncategorized directories with sample symlink files


------
https://chatgpt.com/codex/tasks/task_b_6898d5593c5c8321afbf842728c4197d