### PR TITLE
Write symlink files directly under mirror root

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ This setup disables Rclone's caching and streams directly, since the  end-client
 --allow-other
 ```
 
-* The `--links` setting in RClone is important. It allows *.rclonelink files within the webdav to be translated to symlinks when mounted onto your filesystem.
+* The `--links` setting in RClone is important. It allows *.symlink files within the webdav to be translated to symlinks when mounted onto your filesystem.
 
     > NOTE: Be sure to use an updated version of rclone that supports the `--links` argument.
     > * Version `v1.70.3` has been known to support it.

--- a/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
+++ b/backend/Api/Controllers/GetWebdavItem/GetWebdavItemController.cs
@@ -64,7 +64,7 @@ public class ListWebdavDirectoryController(DatabaseStore store) : BaseApiControl
     {
         var extension = Path.GetExtension(item).ToLower();
         return extension == ".mkv" ? "video/webm"
-            : extension == ".rclonelink" ? "text/plain"
+            : extension == ".symlink" ? "text/plain"
             : extension == ".nfo" ? "text/plain"
             : MimeTypeProvider.TryGetContentType(Path.GetFileName(item), out var mimeType) ? mimeType
             : "application/octet-stream";

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -100,8 +100,8 @@ class Program
                 var path = httpContext.Request.Path.Value?.ToLower() ?? "";
                 var method = httpContext.Request.Method;
                 
-                if (method == "PROPFIND" || 
-                    (method == "GET" && (path.Contains("/api") || path.Contains(".rclonelink"))))
+                if (method == "PROPFIND" ||
+                    (method == "GET" && (path.Contains("/api") || path.Contains(".symlink"))))
                 {
                     return LogEventLevel.Debug;
                 }

--- a/backend/WebDav/DatabaseStoreSymlinkCollection.cs
+++ b/backend/WebDav/DatabaseStoreSymlinkCollection.cs
@@ -56,7 +56,7 @@ public class DatabaseStoreSymlinkCollection : BaseStoreCollection
     protected override async Task<IStoreItem?> GetItemAsync(GetItemRequest request)
     {
         if (DeletedFiles.IsDeleted(request.Name)) return null;
-        var name = Regex.Replace(request.Name, @"\.rclonelink$", "");
+        var name = Regex.Replace(request.Name, @"\.symlink$", "");
         var child = await dbClient.GetDirectoryChildAsync(TargetId, name, request.CancellationToken);
         if (child is null) return null;
         return GetItem(child);
@@ -148,12 +148,11 @@ public class DatabaseStoreSymlinkCollection : BaseStoreCollection
             return;
         }
 
-        var dir = Path.Join(MirrorRoot, RelativePath, item.Name);
-        Directory.CreateDirectory(dir);
-        var filePath = Path.Join(dir, item.Name + ".rclonelink");
+        Directory.CreateDirectory(Path.Join(MirrorRoot, RelativePath));
+        var filePath = Path.Join(MirrorRoot, RelativePath, item.Name + ".symlink");
         var ups = Enumerable.Repeat(
             "..",
-            RelativePath.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries).Length + 2
+            RelativePath.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries).Length + 1
         );
         var target = Path.Combine(
                 ups.Concat(new[] { DavItem.ContentFolder.Name, RelativePath, item.Name }).ToArray()

--- a/backend/WebDav/DatabaseStoreSymlinkFile.cs
+++ b/backend/WebDav/DatabaseStoreSymlinkFile.cs
@@ -12,8 +12,8 @@ namespace NzbWebDAV.WebDav;
 
 public class DatabaseStoreSymlinkFile(DavItem davFile, string parentPath) : BaseStoreItem
 {
-    public override string Name => davFile.Name + ".rclonelink";
-    public override string UniqueKey => davFile.Id + ".rclonelink";
+    public override string Name => davFile.Name + ".symlink";
+    public override string UniqueKey => davFile.Id + ".symlink";
     public override long FileSize => ContentBytes.Length;
 
     private string TargetPath


### PR DESCRIPTION
## Summary
- Create symlink files directly under the mirror directory instead of nesting them in a subfolder
- Rename all `.rclonelink` references to `.symlink` so symlinks and logging use the new extension
- Adjust relative path calculation for symlink targets

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `apt-get install -y dotnet-sdk-9.0` *(fails: Unable to locate package dotnet-sdk-9.0)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68993f3d63188321ae5abd47bbbf74eb