### PR TITLE
Mirror completed items into symlink directory

### DIFF
--- a/backend/Services/QueueItemProcessor.cs
+++ b/backend/Services/QueueItemProcessor.cs
@@ -140,10 +140,11 @@ public class QueueItemProcessor(
         var fileProcessingResults = await TaskUtil.WhenAllOrError(fileProcessingTasks, progress);
 
         // update the database
+        DavItem? mountFolder = null;
         await MarkQueueItemCompleted(startTime, error: null, () =>
         {
             var categoryFolder = GetOrCreateCategoryFolder();
-            var mountFolder = CreateMountFolder(categoryFolder);
+            mountFolder = CreateMountFolder(categoryFolder);
             new RarAggregator(dbClient, mountFolder).UpdateDatabase(fileProcessingResults);
             new FileAggregator(dbClient, mountFolder).UpdateDatabase(fileProcessingResults);
 
@@ -151,6 +152,9 @@ public class QueueItemProcessor(
             if (configManager.IsEnsureImportableVideoEnabled())
                 new EnsureImportableVideoValidator(dbClient).ThrowIfValidationFails();
         });
+
+        if (mountFolder is not null)
+            new SymlinkMirrorService(dbClient, configManager).Mirror(mountFolder);
     }
 
     private BaseProcessor? GetFileProcessor(NzbFile nzbFile)

--- a/backend/Services/SymlinkMirrorService.cs
+++ b/backend/Services/SymlinkMirrorService.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+
+namespace NzbWebDAV.Services;
+
+public class SymlinkMirrorService(
+    DavDatabaseClient dbClient,
+    ConfigManager configManager
+)
+{
+    public void Mirror(DavItem item)
+    {
+        var relativePath = GetRelativePath(item);
+        MirrorItem(item, relativePath);
+    }
+
+    private string GetRelativePath(DavItem item)
+    {
+        var segments = new List<string> { item.Name };
+        var current = item;
+        while (current.ParentId is not null && current.ParentId != DavItem.ContentFolder.Id)
+        {
+            current = dbClient.Ctx.Items.First(x => x.Id == current.ParentId);
+            segments.Add(current.Name);
+        }
+        segments.Reverse();
+        return Path.Join(segments);
+    }
+
+    private void MirrorItem(DavItem item, string relativePath)
+    {
+        var mirrorRoot = configManager.GetSymlinkMirrorDir();
+
+        if (item.Type == DavItem.ItemType.Directory || item.Type == DavItem.ItemType.SymlinkRoot)
+        {
+            Directory.CreateDirectory(Path.Join(mirrorRoot, relativePath));
+            var children = dbClient.Ctx.Items.Where(x => x.ParentId == item.Id).ToList();
+            foreach (var child in children)
+            {
+                MirrorItem(child, Path.Join(relativePath, child.Name));
+            }
+            return;
+        }
+
+        var parentPath = Path.GetDirectoryName(relativePath) ?? "";
+        Directory.CreateDirectory(Path.Join(mirrorRoot, parentPath));
+        var fileName = Path.GetFileName(relativePath);
+        var filePath = Path.Join(mirrorRoot, parentPath, fileName + ".symlink");
+        var depth = parentPath.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries).Length;
+        var ups = Enumerable.Repeat("..", depth + 1);
+        var parts = new List<string>(ups) { DavItem.ContentFolder.Name };
+        if (!string.IsNullOrEmpty(parentPath))
+            parts.Add(parentPath);
+        parts.Add(fileName);
+        var target = Path.Combine(parts.ToArray()).Replace('\\', '/');
+        File.WriteAllText(filePath, target);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `SymlinkMirrorService` to mirror `/content` items into the symlink directory, reusing existing path/target logic.
- Invoke the new service after queue item processing to mirror freshly processed `DavItem`s.

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*


------
https://chatgpt.com/codex/tasks/task_b_6899426469748321a2ac77baf9543589