### PR TITLE
Normalize publish architecture for dotnet build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,11 @@ COPY ./backend ./
 # Accept build-time architecture as ARG (e.g., x64 or arm64)
 ARG TARGETARCH
 RUN dotnet restore
-RUN dotnet publish -c Release -r linux-musl-${TARGETARCH} -o ./publish
+RUN RID_ARCH=${TARGETARCH}; \
+    if [ "${RID_ARCH}" = "amd64" ]; then \
+        RID_ARCH=x64; \
+    fi; \
+    dotnet publish -c Release -r linux-musl-${RID_ARCH} -o ./publish
 
 # -------- Stage 3: Combined runtime image --------
 FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine


### PR DESCRIPTION
## Summary
- Normalize `TARGETARCH` before publishing so `amd64` becomes `x64`
- Publish backend using runtime identifier built from normalized architecture

## Testing
- `dotnet publish -c Release -r linux-musl-x64 -o ./publish` *(fails: Services/SymlinkMirrorService.cs(31,26): error CS1503)*

------
https://chatgpt.com/codex/tasks/task_b_68994ed7a2748321a26674339b71eb98