### PR TITLE
Build backend using TARGETARCH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,18 +16,14 @@ FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0 AS backend-build
 WORKDIR /backend
 COPY ./backend ./
 
-# Accept build-time platform as ARG (e.g., linux/amd64)
-ARG TARGETPLATFORM
-RUN RID_ARCH=$(echo ${TARGETPLATFORM} | cut -d/ -f2); \
+# Accept build-time architecture as ARG
+ARG TARGETARCH
+RUN RID_ARCH=${TARGETARCH}; \
     if [ "${RID_ARCH}" = "amd64" ]; then \
         RID_ARCH=x64; \
     fi; \
-    dotnet restore --runtime linux-musl-${RID_ARCH}
-RUN RID_ARCH=$(echo ${TARGETPLATFORM} | cut -d/ -f2); \
-    if [ "${RID_ARCH}" = "amd64" ]; then \
-        RID_ARCH=x64; \
-    fi; \
-    dotnet publish -c Release --runtime linux-musl-${RID_ARCH} -o ./publish
+    dotnet restore -r linux-musl-${RID_ARCH} && \
+    dotnet publish -c Release -r linux-musl-${RID_ARCH} -o ./publish
 
 # -------- Stage 3: Combined runtime image --------
 FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine


### PR DESCRIPTION
## Summary
- compute backend RID architecture from `$TARGETARCH`
- merge restore and publish and target runtime with `-r`

## Testing
- `docker build --target backend-build .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_b_6899cfaacedc8321ac83e1f57961793e