### PR TITLE
Fix Path.Join usage in SymlinkMirrorService

### DIFF
--- a/backend/Services/SymlinkMirrorService.cs
+++ b/backend/Services/SymlinkMirrorService.cs
@@ -28,7 +28,7 @@ public class SymlinkMirrorService(
             segments.Add(current.Name);
         }
         segments.Reverse();
-        return Path.Join(segments);
+        return Path.Join(segments.ToArray());
     }
 
     private void MirrorItem(DavItem item, string relativePath)


### PR DESCRIPTION
## Summary
- Ensure symlink mirror service joins path segments using an array

## Testing
- `dotnet build backend`


------
https://chatgpt.com/codex/tasks/task_b_6899dc6a07e48321989cae6469d2c79f