### PR TITLE
Add SAB addurl endpoint

### DIFF
--- a/backend/Api/SabControllers/AddFile/AddFileRequest.cs
+++ b/backend/Api/SabControllers/AddFile/AddFileRequest.cs
@@ -39,7 +39,7 @@ public class AddFileRequest()
         };
     }
 
-    private static QueueItem.PriorityOption MapPriorityOption(string? priority)
+    protected static QueueItem.PriorityOption MapPriorityOption(string? priority)
     {
         return priority switch
         {
@@ -55,7 +55,7 @@ public class AddFileRequest()
         };
     }
 
-    private static QueueItem.PostProcessingOption MapPostProcessingOption(string? postProcessing)
+    protected static QueueItem.PostProcessingOption MapPostProcessingOption(string? postProcessing)
     {
         return postProcessing switch
         {

--- a/backend/Api/SabControllers/AddUrl/AddUrlController.cs
+++ b/backend/Api/SabControllers/AddUrl/AddUrlController.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Api.SabControllers.AddFile;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Services;
+
+namespace NzbWebDAV.Api.SabControllers.AddUrl;
+
+public class AddUrlController(
+    HttpContext httpContext,
+    DavDatabaseClient dbClient,
+    QueueManager queueManager,
+    ConfigManager configManager
+) : SabApiController.BaseController(httpContext, configManager)
+{
+    public async Task<AddUrlResponse> AddUrlAsync(AddUrlRequest request)
+    {
+        var controller = new AddFileController(httpContext, dbClient, queueManager, configManager);
+        var response = await controller.AddFileAsync(request);
+        return new AddUrlResponse()
+        {
+            Status = response.Status,
+            NzoIds = response.NzoIds,
+        };
+    }
+
+    protected override async Task<IActionResult> Handle()
+    {
+        var request = await AddUrlRequest.New(httpContext);
+        return Ok(await AddUrlAsync(request));
+    }
+}

--- a/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
+++ b/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
@@ -1,0 +1,75 @@
+using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Api.SabControllers.AddFile;
+using NzbWebDAV.Extensions;
+
+namespace NzbWebDAV.Api.SabControllers.AddUrl;
+
+public class AddUrlRequest() : AddFileRequest
+{
+    public static async Task<AddUrlRequest> New(HttpContext context)
+    {
+        var nzbUrl = context.GetQueryParam("name");
+        var nzbFile = await GetNzbFile(nzbUrl);
+        return new AddUrlRequest()
+        {
+            FileName = nzbFile.FileName,
+            MimeType = nzbFile.ContentType,
+            NzbFileContents = nzbFile.FileContents,
+            Category = context.GetQueryParam("cat") ?? throw new BadHttpRequestException("Invalid cat param"),
+            Priority = MapPriorityOption(context.GetQueryParam("priority")),
+            PostProcessing = MapPostProcessingOption(context.GetQueryParam("pp")),
+            CancellationToken = context.RequestAborted
+        };
+    }
+
+    private static async Task<NzbFileResponse> GetNzbFile(string? url)
+    {
+        try
+        {
+            // validate url
+            if (string.IsNullOrWhiteSpace(url))
+                throw new Exception($"The url is invalid.");
+
+            // fetch url
+            var httpClient = new HttpClient();
+            var response = await httpClient.GetAsync(url);
+            if (!response.IsSuccessStatusCode)
+                throw new Exception($"Received status code {response.StatusCode}.");
+
+            // read the content type
+            var contentType = response.Content.Headers.ContentType?.MediaType;
+            if (string.IsNullOrEmpty(contentType))
+                throw new Exception("Missing Content-Type header.");
+
+            // read the filename
+            var contentDisposition = response.Content.Headers.ContentDisposition;
+            var fileName = contentDisposition?.FileName?.Trim('"');
+            if (string.IsNullOrEmpty(fileName))
+                throw new Exception("Filename could not be determined from Content-Disposition header.");
+
+            // read the file contents
+            var fileContents = await response.Content.ReadAsStringAsync();
+            if (string.IsNullOrWhiteSpace(fileContents))
+                throw new Exception("NZB file contents are empty.");
+
+            // return response
+            return new NzbFileResponse
+            {
+                FileName = fileName,
+                ContentType = contentType,
+                FileContents = fileContents
+            };
+        }
+        catch (Exception ex)
+        {
+            throw new BadHttpRequestException($"Failed to fetch nzb-file url `{url}`: {ex.Message}");
+        }
+    }
+
+    private class NzbFileResponse
+    {
+        public required string FileName { get; init; }
+        public required string ContentType { get; init; }
+        public required string FileContents { get; init; }
+    }
+}

--- a/backend/Api/SabControllers/AddUrl/AddUrlResponse.cs
+++ b/backend/Api/SabControllers/AddUrl/AddUrlResponse.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace NzbWebDAV.Api.SabControllers.AddUrl;
+
+public class AddUrlResponse : SabBaseResponse
+{
+    [JsonPropertyName("nzo_ids")]
+    public List<string> NzoIds { get; set; } = [];
+}

--- a/backend/Api/SabControllers/SabApiController.cs
+++ b/backend/Api/SabControllers/SabApiController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NzbWebDAV.Api.SabControllers.AddFile;
+using NzbWebDAV.Api.SabControllers.AddUrl;
 using NzbWebDAV.Api.SabControllers.ClearQueue;
 using NzbWebDAV.Api.SabControllers.GetConfig;
 using NzbWebDAV.Api.SabControllers.GetFullStatus;
@@ -72,6 +73,8 @@ public class SabApiController(
                 return new GetFullStatusController(HttpContext, configManager);
             case "addfile":
                 return new AddFileController(HttpContext, dbClient, queueManager, configManager);
+            case "addurl":
+                return new AddUrlController(HttpContext, dbClient, queueManager, configManager);
 
             case "queue" when HttpContext.GetQueryParam("name") == "delete":
                 return new RemoveFromQueueController(HttpContext, dbClient, queueManager, configManager);


### PR DESCRIPTION
## Summary
- add controller, request, and response for SAB `addurl` support
- expose priority and post processing mapping on AddFileRequest for reuse
- register `addurl` action in SAB API controller

## Testing
- `~/.dotnet/dotnet build backend/NzbWebDAV.csproj`
- `curl -s "http://localhost:5005/api?mode=addurl&name=http://localhost:8001/test.nzb&cat=movies&apikey=testkey"`

------
https://chatgpt.com/codex/tasks/task_b_68a75eea82d8832187ffa0b5cbeea963