### PR TITLE
Fix config directory ownership in entrypoint script

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,8 +46,8 @@ if [ -z "${FRONTEND_BACKEND_API_KEY}" ]; then
     export FRONTEND_BACKEND_API_KEY=$(head -c 32 /dev/urandom | hexdump -ve '1/1 "%.2x"')
 fi
 
-# Change permissions on /config directory to the given PUID and GUID
-chown $PUID:$GUID /config
+# Change permissions on /config directory to the given PUID and PGID
+chown $PUID:$PGID /config
 
 # Run backend as appuser in background
 cd /app/backend


### PR DESCRIPTION
## Summary
- correct group variable to `$PGID` when chowning `/config`
- ensure `entrypoint.sh` ends with a newline for proper shell execution

## Testing
- `npm test` *(fails: Missing script "test")*
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_b_68a75eeb01948321b49f5d0b342e629c