### PR TITLE
Filter symlink collection to completed downloads

### DIFF
--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -133,4 +133,16 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
     {
         public long TotalSize { get; init; }
     }
+
+    // completed-symlinks
+    public async Task<List<DavItem>> GetCompletedSymlinkCategoryChildren(string category, CancellationToken ct = default)
+    {
+        var query = from historyItem in Ctx.HistoryItems
+            where historyItem.Category == category
+                  && historyItem.DownloadStatus == HistoryItem.DownloadStatusOption.Completed
+            join davItem in Ctx.Items on historyItem.JobName equals davItem.Name
+            where davItem.Type == DavItem.ItemType.Directory
+            select davItem;
+        return await query.Distinct().ToListAsync(ct);
+    }
 }

--- a/backend/WebDav/DatabaseStoreSymlinkCollection.cs
+++ b/backend/WebDav/DatabaseStoreSymlinkCollection.cs
@@ -18,7 +18,7 @@ public class DatabaseStoreSymlinkCollection(
     public override string Name => davDirectory.Name;
     public override string UniqueKey => davDirectory.Id.ToString();
 
-    private string RelativePath => davDirectory.Id == DavItem.SymlinkFolder.Id ? "" : Path.Join(parentPath, Name);
+    private string RelativePath => davDirectory.Id == DavItem.SymlinkFolder.Id ? "" : Path.Combine(parentPath, Name);
     private Guid TargetId => davDirectory.Id == DavItem.SymlinkFolder.Id ? DavItem.ContentFolder.Id : davDirectory.Id;
     private DeletedFileManager DeletedFiles => new(davDirectory.Id);
 
@@ -38,7 +38,14 @@ public class DatabaseStoreSymlinkCollection(
 
     protected override async Task<IStoreItem[]> GetAllItemsAsync(CancellationToken cancellationToken)
     {
-        return (await dbClient.GetDirectoryChildrenAsync(TargetId, cancellationToken))
+        // if we are a category folder within the /completed-symlinks dir,
+        // then we only want to show children that correspond to Completed History items.
+        var isCategoryFolder = davDirectory.ParentId == DavItem.ContentFolder.Id;
+        var children = isCategoryFolder
+            ? await dbClient.GetCompletedSymlinkCategoryChildren(davDirectory.Name, cancellationToken)
+            : await dbClient.GetDirectoryChildrenAsync(TargetId, cancellationToken);
+
+        return children
             .Select(GetItem)
             .Where(x => !DeletedFiles.IsDeleted(x.Name)) // must appear after Select(GetItem) for correct Name.
             .ToArray();


### PR DESCRIPTION
## Summary
- add query to get completed symlink category items from history
- filter symlink collections to only completed downloads
- use Path.Combine for symlink paths

## Testing
- `dotnet build backend/NzbWebDAV.csproj`

------
https://chatgpt.com/codex/tasks/task_b_68a75eeb818c8321a182d7d5e31c3454