### PR TITLE
Add optional flag to remove completed files from history

### DIFF
--- a/backend/Api/SabControllers/RemoveFromHistory/RemoveFromHistoryController.cs
+++ b/backend/Api/SabControllers/RemoveFromHistory/RemoveFromHistoryController.cs
@@ -13,7 +13,7 @@ public class RemoveFromHistoryController(
 {
     public async Task<RemoveFromHistoryResponse> RemoveFromHistory(RemoveFromHistoryRequest request)
     {
-        await dbClient.RemoveHistoryItemAsync(request.NzoId);
+        await dbClient.RemoveHistoryItemAsync(request.NzoId, request.DelCompletedFiles);
         return new RemoveFromHistoryResponse() { Status = true };
     }
 

--- a/backend/Api/SabControllers/RemoveFromHistory/RemoveFromHistoryRequest.cs
+++ b/backend/Api/SabControllers/RemoveFromHistory/RemoveFromHistoryRequest.cs
@@ -6,11 +6,14 @@ namespace NzbWebDAV.Api.SabControllers.RemoveFromHistory;
 public class RemoveFromHistoryRequest()
 {
     public string NzoId { get; init; } = string.Empty;
+    public bool DelCompletedFiles { get; init; }
     public CancellationToken CancellationToken { get; init; }
 
     public RemoveFromHistoryRequest(HttpContext httpContext): this()
     {
         NzoId = httpContext.GetQueryParam("value")!;
+        var delParam = httpContext.GetQueryParam("del_completed_files");
+        DelCompletedFiles = delParam == "1" || bool.TryParse(delParam, out var b) && b;
         CancellationToken = httpContext.RequestAborted;
     }
 }

--- a/backend/Api/SabControllers/SabApiController.cs
+++ b/backend/Api/SabControllers/SabApiController.cs
@@ -62,32 +62,29 @@ public class SabApiController(
 
     public BaseController GetController()
     {
-        switch (HttpContext.GetQueryParam("mode"))
+        var mode = HttpContext.GetQueryParam("mode");
+        var name = HttpContext.GetQueryParam("name");
+
+        return mode switch
         {
-            case "version":
-                return new GetVersionController(HttpContext, configManager);
-            case "get_config":
-                return new GetConfigController(HttpContext, configManager);
-            case "fullstatus":
-                return new GetFullStatusController(HttpContext, configManager);
-            case "addfile":
-                return new AddFileController(HttpContext, dbClient, queueManager, configManager);
+            "version" => new GetVersionController(HttpContext, configManager),
+            "get_config" => new GetConfigController(HttpContext, configManager),
+            "fullstatus" => new GetFullStatusController(HttpContext, configManager),
+            "addfile" => new AddFileController(HttpContext, dbClient, queueManager, configManager),
 
-            case "queue" when HttpContext.GetQueryParam("name") == "delete":
-                return new RemoveFromQueueController(HttpContext, dbClient, queueManager, configManager);
-            case "queue" when HttpContext.GetQueryParam("name") == "delete_all":
-                return new ClearQueueController(HttpContext, dbClient, configManager, queueManager);
-            case "queue":
-                return new GetQueueController(HttpContext, dbClient, queueManager, configManager);
+            "queue" when name == "delete" =>
+                new RemoveFromQueueController(HttpContext, dbClient, queueManager, configManager),
+            "queue" when name == "delete_all" =>
+                new ClearQueueController(HttpContext, dbClient, configManager, queueManager),
+            "queue" => new GetQueueController(HttpContext, dbClient, queueManager, configManager),
 
-            case "history" when HttpContext.GetQueryParam("name") == "delete":
-                return new RemoveFromHistoryController(HttpContext, dbClient, configManager);
-            case "history":
-                return new GetHistoryController(HttpContext, dbClient, configManager);
+            // del_completed_files handled within RemoveFromHistoryController
+            "history" when name == "delete" =>
+                new RemoveFromHistoryController(HttpContext, dbClient, configManager),
+            "history" => new GetHistoryController(HttpContext, dbClient, configManager),
 
-            default:
-                throw new BadHttpRequestException("Invalid mode");
-        }
+            _ => throw new BadHttpRequestException("Invalid mode"),
+        };
     }
 
     public abstract class BaseController(HttpContext httpContext, ConfigManager configManager) : ControllerBase


### PR DESCRIPTION
## Summary
- support `del_completed_files` flag in history deletion request
- propagate deletion preference through API controller
- remove completed content and history entries when flag is set

## Testing
- `dotnet test backend/NzbWebDAV.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*


------
https://chatgpt.com/codex/tasks/task_b_68a75eec73508321b18c1cea10de74a9