### PR TITLE
Ensure RAR aggregator creates paths under /extracted root

### DIFF
--- a/backend/Services/FileAggregators/RarAggregator.cs
+++ b/backend/Services/FileAggregators/RarAggregator.cs
@@ -74,12 +74,15 @@ public class RarAggregator(DavDatabaseClient dbClient, DavItem mountDirectory) :
 
     private DavItem EnsurePath(string pathWithinArchive)
     {
-        var pathSegments = pathWithinArchive.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var pathSegments = pathWithinArchive
+            .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            .Prepend("extracted")
+            .ToArray();
         var parentDirectory = mountDirectory;
         var pathKey = "";
         for (var i = 0; i < pathSegments.Length - 1; i++)
         {
-            pathKey = Path.Join(pathKey, pathSegments[i]);
+            pathKey = Path.Combine(pathKey, pathSegments[i]);
             parentDirectory = EnsureDirectory(parentDirectory, pathSegments[i], pathKey);
         }
 


### PR DESCRIPTION
## Summary
- prefix archive file paths with `extracted` when aggregating RAR parts
- use `Path.Combine` for building extraction paths for Windows compatibility

## Testing
- `dotnet build backend/NzbWebDAV.csproj`
- `dotnet run` (verification of combined path and symlink resolution)


------
https://chatgpt.com/codex/tasks/task_b_68a75eed973883219ccb5c8bd349d562