### PR TITLE
Handle NZB files lacking segments

### DIFF
--- a/backend/Clients/CachingNntpClient.cs
+++ b/backend/Clients/CachingNntpClient.cs
@@ -23,6 +23,8 @@ public class CachingNntpClient(INntpClient client, MemoryCache cache) : Wrapping
 
     public override async Task<long> GetFileSizeAsync(NzbFile file, CancellationToken cancellationToken)
     {
+        if (file.Segments.Count == 0) return 0;
+
         var header = await GetSegmentYencHeaderAsync(file.Segments[0].MessageId, cancellationToken);
         return header.FileSize;
     }

--- a/backend/Clients/ThreadSafeNntpClient.cs
+++ b/backend/Clients/ThreadSafeNntpClient.cs
@@ -76,6 +76,8 @@ public class ThreadSafeNntpClient : INntpClient
 
     public async Task<long> GetFileSizeAsync(NzbFile file, CancellationToken cancellationToken)
     {
+        if (file.Segments.Count == 0) return 0;
+
         var header = await GetSegmentYencHeaderAsync(file.Segments[0].MessageId.Value, cancellationToken);
         return header.FileSize;
     }

--- a/backend/Services/QueueItemProcessor.cs
+++ b/backend/Services/QueueItemProcessor.cs
@@ -129,7 +129,11 @@ public class QueueItemProcessor(
         var nzb = await NzbDocument.LoadAsync(stream);
 
         // start the file processing tasks
-        var fileProcessingTasks = nzb.Files
+        var nzbFiles = nzb.Files
+            .Where(x => x.Segments.Count > 0)
+            .ToList();
+
+        var fileProcessingTasks = nzbFiles
             .DistinctBy(x => x.GetSubjectFileName())
             .Select(GetFileProcessor)
             .Where(x => x is not null)


### PR DESCRIPTION
## Summary
- guard file size requests against NZB files without segments in caching and thread-safe NNTP clients
- fall back to zero file size and a safe filename when NZB files lack segments during processing
- skip NZB files that contain no segments when queuing processing tasks

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*
- `/tmp/dotnet9/dotnet build backend/NzbWebDAV.csproj -v:minimal`

------
https://chatgpt.com/codex/tasks/task_b_68a7b0bb784083219ba5959d41b9cb44