### PR TITLE
Add ability to remove history items

### DIFF
--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -131,6 +131,20 @@ class BackendClient {
         }
     }
 
+    public async removeHistory(nzoId: string): Promise<void> {
+        const url = process.env.BACKEND_URL + `/api?mode=history&name=delete&value=${nzoId}&del_completed_files=0`;
+
+        const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
+        const response = await fetch(url, {
+            method: "POST",
+            headers: { "x-api-key": apiKey }
+        });
+
+        if (!response.ok) {
+            throw new Error(`Failed to remove history item: ${(await response.json()).error}`);
+        }
+    }
+
     public async listWebdavDirectory(directory: string): Promise<DirectoryItem[]> {
         const url = process.env.BACKEND_URL + "/api/list-webdav-directory";
 

--- a/frontend/app/routes/queue/components/history-table/history-table.module.css
+++ b/frontend/app/routes/queue/components/history-table/history-table.module.css
@@ -52,3 +52,7 @@
 .table-row:hover {
     background-color: hsl(200 20% 8%) !important;
 }
+
+.action-form {
+    display: inline;
+}

--- a/frontend/app/routes/queue/components/history-table/history-table.module.css.d.ts
+++ b/frontend/app/routes/queue/components/history-table/history-table.module.css.d.ts
@@ -6,6 +6,7 @@ declare const styles: {
   readonly "table-header": string;
   readonly "table-row": string;
   readonly "truncate": string;
+  readonly "action-form": string;
 };
 export = styles;
 

--- a/frontend/app/routes/queue/components/history-table/history-table.tsx
+++ b/frontend/app/routes/queue/components/history-table/history-table.tsx
@@ -1,6 +1,7 @@
 import type { HistoryResponse } from "~/clients/backend-client.server"
 import styles from "./history-table.module.css"
-import { Table } from "react-bootstrap"
+import { Table, Button } from "react-bootstrap"
+import { Form } from "react-router"
 import { CategoryBadge, formatFileSize, StatusBadge } from "../queue-table/queue-table"
 
 export type HistoryTableProps = {
@@ -16,7 +17,8 @@ export function HistoryTable({ history }: HistoryTableProps) {
                     <th className={styles["first-table-header"]}>Name</th>
                     <th className={styles["table-header"]}>Category</th>
                     <th className={styles["table-header"]}>Status</th>
-                    <th className={styles["last-table-header"]}>Size</th>
+                    <th className={styles["table-header"]}>Size</th>
+                    <th className={styles["last-table-header"]}>Actions</th>
                 </tr>
             </thead>
             <tbody>
@@ -35,6 +37,14 @@ export function HistoryTable({ history }: HistoryTableProps) {
                         </td>
                         <td className={styles["row-column"]}>
                             {formatFileSize(slot.bytes)}
+                        </td>
+                        <td className={styles["row-column"]}>
+                            <Form method="post" className={styles["action-form"]}>
+                                <input type="hidden" name="nzoId" value={slot.nzo_id} />
+                                <Button variant="danger" type="submit" name="intent" value="remove-history">
+                                    Remove
+                                </Button>
+                            </Form>
                         </td>
                     </tr>
                 )}

--- a/frontend/app/routes/queue/route.tsx
+++ b/frontend/app/routes/queue/route.tsx
@@ -131,6 +131,26 @@ export async function action({ request }: Route.ActionArgs) {
         return clearQueueAction({ request, params: {}, context: { VALUE_FROM_EXPRESS: '' } });
     }
 
+    if (intent === "remove-history") {
+        let session = await sessionStorage.getSession(request.headers.get("cookie"));
+        let user = session.get("user");
+        if (!user) return redirect("/login");
+
+        try {
+            const nzoId = formData.get("nzoId");
+            if (typeof nzoId !== "string") {
+                return { error: "Error removing history." };
+            }
+            await backendClient.removeHistory(nzoId);
+            return { success: true };
+        } catch (error) {
+            if (error instanceof Error) {
+                return { error: error.message };
+            }
+            throw error;
+        }
+    }
+
     let session = await sessionStorage.getSession(request.headers.get("cookie"));
     let user = session.get("user");
     if (!user) return redirect("/login");


### PR DESCRIPTION
## Summary
- add backend client helper to remove history entries
- support remove-history action in queue route
- display actions column with remove button for history items

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_b_68a7b2157a7c8321a622e943e120f6e4