### PR TITLE
Add API route for migrating library symlinks and update maintenance UI

### DIFF
--- a/frontend/app/routes/api.migrate-library-symlinks.ts
+++ b/frontend/app/routes/api.migrate-library-symlinks.ts
@@ -1,0 +1,15 @@
+import type { Route } from "./+types/api.migrate-library-symlinks";
+import { backendClient } from "~/clients/backend-client.server";
+
+export async function action({ request }: Route.ActionArgs) {
+    try {
+        await backendClient.migrateLibrarySymlinks();
+        return Response.json({ status: "ok" });
+    } catch (error) {
+        console.error("Migrate library symlinks error:", error);
+        return Response.json(
+            { error: error instanceof Error ? error.message : "Failed to migrate library symlinks" },
+            { status: 500 }
+        );
+    }
+}

--- a/frontend/app/routes/settings/maintenance/maintenance.tsx
+++ b/frontend/app/routes/settings/maintenance/maintenance.tsx
@@ -1,10 +1,11 @@
 import { Button } from "react-bootstrap";
 import styles from "./maintenance.module.css";
 import React from "react";
-import { backendClient } from "~/clients/backend-client.server";
+import { useFetcher } from "react-router";
 
 export function MaintenanceSettings() {
     const [messages, setMessages] = React.useState<string[]>([]);
+    const fetcher = useFetcher();
 
     React.useEffect(() => {
         const url = (process.env.BACKEND_URL || "").replace(/^http/, "ws") + "/ws";
@@ -20,8 +21,18 @@ export function MaintenanceSettings() {
         return () => ws.close();
     }, []);
 
-    const onMigrate = async () => {
-        await backendClient.migrateLibrarySymlinks();
+    React.useEffect(() => {
+        if (fetcher.state === "idle" && fetcher.data) {
+            if (fetcher.data.error) {
+                setMessages(prev => [...prev, `Error: ${fetcher.data.error}`]);
+            } else {
+                setMessages(prev => [...prev, "Migration started"]);
+            }
+        }
+    }, [fetcher.state, fetcher.data]);
+
+    const onMigrate = () => {
+        fetcher.submit(null, { method: "post", action: "/api/migrate-library-symlinks" });
     };
 
     return (


### PR DESCRIPTION
## Summary
- add server route `api.migrate-library-symlinks` that calls `backendClient.migrateLibrarySymlinks`
- update maintenance settings to trigger migration via fetcher instead of importing server client
- surface migration start and error messages in the maintenance page

## Testing
- `cd frontend && npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68a86bf760c083218447e64d45a9d67e