### PR TITLE
refactor: avoid top-level server imports

### DIFF
--- a/frontend/app/routes/_index/route.tsx
+++ b/frontend/app/routes/_index/route.tsx
@@ -1,8 +1,8 @@
 import { redirect } from "react-router";
 import type { Route } from "./+types/route";
-import { sessionStorage } from "~/auth/authentication.server";
 
 export async function loader({ request }: Route.LoaderArgs) {
+    const { sessionStorage } = await import("~/auth/authentication.server");
     let session = await sessionStorage.getSession(request.headers.get("cookie"));
     let user = session.get("user");
     if (!user) return redirect("/login");

--- a/frontend/app/routes/api.backend.migrate-library-symlinks.ts
+++ b/frontend/app/routes/api.backend.migrate-library-symlinks.ts
@@ -1,0 +1,12 @@
+import type { Route } from "./+types/api.backend.migrate-library-symlinks";
+import { redirect } from "react-router";
+
+export async function action({ request }: Route.ActionArgs) {
+    const { sessionStorage } = await import("~/auth/authentication.server");
+    const { backendClient } = await import("~/clients/backend-client.server");
+    const session = await sessionStorage.getSession(request.headers.get("cookie"));
+    const user = session.get("user");
+    if (!user) return redirect("/login");
+    await backendClient.migrateLibrarySymlinks();
+    return new Response(null, { status: 204 });
+}

--- a/frontend/app/routes/api.frontend.connection-stats.ts
+++ b/frontend/app/routes/api.frontend.connection-stats.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.frontend.connection-stats";
-import { backendClient } from "~/clients/backend-client.server";
 
 export async function loader({ request }: Route.LoaderArgs) {
+    const { backendClient } = await import("~/clients/backend-client.server");
     try {
         const connectionStats = await backendClient.getConnectionStats();
         return Response.json(connectionStats);

--- a/frontend/app/routes/explore/route.tsx
+++ b/frontend/app/routes/explore/route.tsx
@@ -5,11 +5,9 @@ import { LeftNavigation } from "../_index/components/left-navigation/left-naviga
 import { Breadcrumbs } from "./breadcrumbs/breadcrumbs";
 import styles from "./route.module.css"
 import { Link, redirect, useLocation, useNavigate } from "react-router";
-import { backendClient, type DirectoryItem } from "~/clients/backend-client.server";
-import { sessionStorage } from "~/auth/authentication.server";
+import type { DirectoryItem } from "~/clients/backend-client.server";
 import { useCallback } from "react";
 import { lookup as getMimeType } from 'mime-types';
-import { getDownloadKey } from "~/auth/downloads.server";
 
 export type ExplorePageData = {
     parentDirectories: string[],
@@ -23,6 +21,9 @@ export type ExploreFile = DirectoryItem & {
 
 
 export async function loader({ request }: Route.LoaderArgs) {
+    const { sessionStorage } = await import("~/auth/authentication.server");
+    const { backendClient } = await import("~/clients/backend-client.server");
+    const { getDownloadKey } = await import("~/auth/downloads.server");
     let session = await sessionStorage.getSession(request.headers.get("cookie"));
     let user = session.get("user");
     if (!user) return redirect("/login");

--- a/frontend/app/routes/login/route.tsx
+++ b/frontend/app/routes/login/route.tsx
@@ -1,15 +1,15 @@
 import { Alert, Button, Form as BootstrapForm } from "react-bootstrap";
 import styles from "./route.module.css"
 import type { Route } from "./+types/route";
-import { authenticate, sessionStorage } from "~/auth/authentication.server";
 import { Form, redirect, useNavigation } from "react-router";
-import { backendClient } from "~/clients/backend-client.server";
 
 type LoginPageData = {
     loginError: string
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
+    const { sessionStorage } = await import("~/auth/authentication.server");
+    const { backendClient } = await import("~/clients/backend-client.server");
     // if already logged in, redirect to landing page
     let session = await sessionStorage.getSession(request.headers.get("cookie"));
     let user = session.get("user");
@@ -47,8 +47,9 @@ export default function Index({ loaderData, actionData }: Route.ComponentProps) 
 
 export async function action({ request }: Route.ActionArgs) {
     try {
-        let user = await authenticate(request);
-        let session = await sessionStorage.getSession(request.headers.get("cookie"));
+        const { authenticate, sessionStorage } = await import("~/auth/authentication.server");
+        const user = await authenticate(request);
+        const session = await sessionStorage.getSession(request.headers.get("cookie"));
         session.set("user", user);
         return redirect("/", { headers: { "Set-Cookie": await sessionStorage.commitSession(session) } });
     }

--- a/frontend/app/routes/logout/route.tsx
+++ b/frontend/app/routes/logout/route.tsx
@@ -1,8 +1,8 @@
 import type { Route } from "./+types/route";
-import { sessionStorage } from "~/auth/authentication.server";
 import { redirect } from "react-router";
 
 export async function action({ request }: Route.ActionArgs) {
+    const { sessionStorage } = await import("~/auth/authentication.server");
     // if already logged out, redirect to login page
     let session = await sessionStorage.getSession(request.headers.get("cookie"));
     let user = session.get("user");

--- a/frontend/app/routes/onboarding/route.tsx
+++ b/frontend/app/routes/onboarding/route.tsx
@@ -2,15 +2,15 @@ import { Alert, Button, Form as BootstrapForm } from "react-bootstrap";
 import styles from "./route.module.css"
 import type { Route } from "./+types/route";
 import { useState } from "react";
-import { backendClient } from "~/clients/backend-client.server";
 import { Form, redirect, useNavigation } from "react-router";
-import { sessionStorage } from "~/auth/authentication.server";
 
 type OnboardingPageData = {
     error: string
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
+    const { sessionStorage } = await import("~/auth/authentication.server");
+    const { backendClient } = await import("~/clients/backend-client.server");
     // if already logged in, redirect to landing page
     let session = await sessionStorage.getSession(request.headers.get("cookie"));
     let user = session.get("user");
@@ -100,9 +100,11 @@ export async function action({ request }: Route.ActionArgs) {
         const username = formData.get("username")?.toString();
         const password = formData.get("password")?.toString();
         if (!username || !password) throw new Error("username and password required");
-        var isSuccess = await backendClient.createAccount(username, password);
+        const { backendClient } = await import("~/clients/backend-client.server");
+        const { sessionStorage } = await import("~/auth/authentication.server");
+        const isSuccess = await backendClient.createAccount(username, password);
         if (!isSuccess) throw new Error("Unknown error creating account");
-        let session = await sessionStorage.getSession(request.headers.get("cookie"));
+        const session = await sessionStorage.getSession(request.headers.get("cookie"));
         session.set("user", { username: username });
         return redirect("/", { headers: { "Set-Cookie": await sessionStorage.commitSession(session) } });
     }

--- a/frontend/app/routes/queue/actions.server.ts
+++ b/frontend/app/routes/queue/actions.server.ts
@@ -1,9 +1,9 @@
 import { redirect } from "react-router";
-import { sessionStorage } from "~/auth/authentication.server";
-import { backendClient } from "~/clients/backend-client.server";
 import type { Route } from "./+types/route";
 
 export async function clearQueueAction({ request }: Route.ActionArgs) {
+    const { sessionStorage } = await import("~/auth/authentication.server");
+    const { backendClient } = await import("~/clients/backend-client.server");
     let session = await sessionStorage.getSession(request.headers.get("cookie"));
     let user = session.get("user");
     if (!user) return redirect("/login");

--- a/frontend/app/routes/queue/route.tsx
+++ b/frontend/app/routes/queue/route.tsx
@@ -1,13 +1,11 @@
 import { redirect } from "react-router";
-import { clearQueueAction } from "./actions.server";
 import type { Route } from "./+types/route";
-import { sessionStorage } from "~/auth/authentication.server";
 import { Layout } from "../_index/components/layout/layout";
 import { TopNavigation } from "../_index/components/top-navigation/top-navigation";
 import { LeftNavigation } from "../_index/components/left-navigation/left-navigation";
 import styles from "./route.module.css"
 import { Alert } from 'react-bootstrap';
-import { backendClient, type HistoryResponse, type QueueResponse } from "~/clients/backend-client.server";
+import type { HistoryResponse, QueueResponse } from "~/clients/backend-client.server";
 import { EmptyQueue } from "./components/empty-queue/empty-queue";
 import { EmptyHistory } from "./components/empty-history/empty-history";
 import { HistoryTable } from "./components/history-table/history-table";
@@ -22,14 +20,16 @@ type BodyProps = {
 };
 
 export async function loader({ request }: Route.LoaderArgs) {
+    const { sessionStorage } = await import("~/auth/authentication.server");
+    const { backendClient } = await import("~/clients/backend-client.server");
     let session = await sessionStorage.getSession(request.headers.get("cookie"));
     let user = session.get("user");
     if (!user) return redirect("/login");
 
-    var queuePromise = backendClient.getQueue();
-    var historyPromise = backendClient.getHistory();
-    var queue = await queuePromise;
-    var history = await historyPromise;
+    const queuePromise = backendClient.getQueue();
+    const historyPromise = backendClient.getHistory();
+    const queue = await queuePromise;
+    const history = await historyPromise;
     return {
         queue: queue,
         history: history,
@@ -128,10 +128,13 @@ export async function action({ request }: Route.ActionArgs) {
     const intent = formData.get("intent");
 
     if (intent === "clear-queue") {
+        const { clearQueueAction } = await import("./actions.server");
         return clearQueueAction({ request, params: {}, context: { VALUE_FROM_EXPRESS: '' } });
     }
 
     if (intent === "remove-history") {
+        const { sessionStorage } = await import("~/auth/authentication.server");
+        const { backendClient } = await import("~/clients/backend-client.server");
         let session = await sessionStorage.getSession(request.headers.get("cookie"));
         let user = session.get("user");
         if (!user) return redirect("/login");
@@ -151,6 +154,8 @@ export async function action({ request }: Route.ActionArgs) {
         }
     }
 
+    const { sessionStorage } = await import("~/auth/authentication.server");
+    const { backendClient } = await import("~/clients/backend-client.server");
     let session = await sessionStorage.getSession(request.headers.get("cookie"));
     let user = session.get("user");
     if (!user) return redirect("/login");

--- a/frontend/app/routes/settings.test-usenet-connection/route.tsx
+++ b/frontend/app/routes/settings.test-usenet-connection/route.tsx
@@ -1,9 +1,9 @@
 import type { Route } from "./+types/route";
-import { backendClient } from "~/clients/backend-client.server";
 import { redirect } from "react-router";
-import { sessionStorage } from "~/auth/authentication.server";
 
 export async function action({ request }: Route.ActionArgs) {
+    const { sessionStorage } = await import("~/auth/authentication.server");
+    const { backendClient } = await import("~/clients/backend-client.server");
     // ensure user is logged in
     let session = await sessionStorage.getSession(request.headers.get("cookie"));
     let user = session.get("user");

--- a/frontend/app/routes/settings.update/route.tsx
+++ b/frontend/app/routes/settings.update/route.tsx
@@ -1,9 +1,10 @@
 import type { Route } from "./+types/route";
-import { backendClient, type ConfigItem } from "~/clients/backend-client.server";
+import type { ConfigItem } from "~/clients/backend-client.server";
 import { redirect } from "react-router";
-import { sessionStorage } from "~/auth/authentication.server";
 
 export async function action({ request }: Route.ActionArgs) {
+    const { sessionStorage } = await import("~/auth/authentication.server");
+    const { backendClient } = await import("~/clients/backend-client.server");
     // ensure user is logged in
     let session = await sessionStorage.getSession(request.headers.get("cookie"));
     let user = session.get("user");

--- a/frontend/app/routes/settings/maintenance/maintenance.tsx
+++ b/frontend/app/routes/settings/maintenance/maintenance.tsx
@@ -1,7 +1,6 @@
 import { Button } from "react-bootstrap";
 import styles from "./maintenance.module.css";
 import React from "react";
-import { backendClient } from "~/clients/backend-client.server";
 
 export function MaintenanceSettings() {
     const [messages, setMessages] = React.useState<string[]>([]);
@@ -21,7 +20,7 @@ export function MaintenanceSettings() {
     }, []);
 
     const onMigrate = async () => {
-        await backendClient.migrateLibrarySymlinks();
+        await fetch("/api.backend.migrate-library-symlinks", { method: "POST" });
     };
 
     return (

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -4,9 +4,7 @@ import { TopNavigation } from "../_index/components/top-navigation/top-navigatio
 import { LeftNavigation } from "../_index/components/left-navigation/left-navigation";
 import styles from "./route.module.css"
 import { Tabs, Tab, Button, Form } from "react-bootstrap"
-import { backendClient } from "~/clients/backend-client.server";
 import { redirect } from "react-router";
-import { sessionStorage } from "~/auth/authentication.server";
 import { UsenetProviders } from "./usenet-providers/usenet-providers";
 
 // Helper function to check if provider settings have been updated
@@ -44,13 +42,15 @@ const defaultConfig = {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
+    const { sessionStorage } = await import("~/auth/authentication.server");
+    const { backendClient } = await import("~/clients/backend-client.server");
     // ensure user is logged in
     let session = await sessionStorage.getSession(request.headers.get("cookie"));
     let user = session.get("user");
     if (!user) return redirect("/login");
 
     // fetch the config items
-    var configItems = await backendClient.getConfig(Object.keys(defaultConfig));
+    const configItems = await backendClient.getConfig(Object.keys(defaultConfig));
 
     // transform to a map
     const config: Record<string, string> = defaultConfig;


### PR DESCRIPTION
## Summary
- dynamically import server utilities within route loaders and actions
- add API route for migrating library symlinks and use it in maintenance settings

## Testing
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a86bf95df88321886bd7ac85148d0d