### PR TITLE
feat: centralize connection parsing

### DIFF
--- a/backend/Clients/UsenetStreamingClient.cs
+++ b/backend/Clients/UsenetStreamingClient.cs
@@ -23,7 +23,7 @@ public class UsenetStreamingClient
         var useSsl = bool.Parse(configManager.GetProviderConfigValue(providerIndex, "use-ssl") ?? "false");
         var user = configManager.GetProviderConfigValue(providerIndex, "user") ?? string.Empty;
         var pass = configManager.GetProviderConfigValue(providerIndex, "pass") ?? string.Empty;
-        var connections = int.Parse(configManager.GetProviderConfigValue(providerIndex, "connections") ?? "10");
+        var connections = configManager.GetMaxConnections();
 
         // initialize the nntp-client
         var createNewConnection = (CancellationToken ct) => CreateNewConnection(host, port, useSsl, user, pass, ct);
@@ -40,11 +40,11 @@ public class UsenetStreamingClient
 
             // if unrelated config changed, do nothing
             var relevantChange = configEventArgs.ChangedConfig.Keys.Any(key =>
-                key == "usenet.providers.primary" || key.StartsWith(prefix));
+                key == "usenet.providers.primary" || key.StartsWith(prefix) || key == "usenet.connections");
             if (!relevantChange) return;
 
             // update the connection-pool according to the new config
-            var connectionCount = int.Parse(configManager.GetProviderConfigValue(providerIndex, "connections") ?? "10");
+            var connectionCount = configManager.GetMaxConnections();
             var newHost = configManager.GetProviderConfigValue(providerIndex, "host") ?? string.Empty;
             var newPort = int.Parse(configManager.GetProviderConfigValue(providerIndex, "port") ?? "119");
             var newUseSsl = bool.Parse(configManager.GetProviderConfigValue(providerIndex, "use-ssl") ?? "false");

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -2,6 +2,7 @@
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Utils;
+using System.Globalization;
 
 namespace NzbWebDAV.Config;
 
@@ -75,6 +76,34 @@ public class ConfigManager
             StringUtil.EmptyToNull(GetConfigValue("usenet.connections-per-stream"))
             ?? StringUtil.EmptyToNull(Environment.GetEnvironmentVariable("CONNECTIONS_PER_STREAM"))
             ?? "1"
+        );
+    }
+
+    /// <summary>
+    /// Gets the maximum number of Usenet connections allowed. Defaults to 10.
+    /// </summary>
+    public int GetMaxConnections()
+    {
+        var providerIndex = GetPrimaryProviderIndex();
+        return int.Parse(
+            StringUtil.EmptyToNull(GetProviderConfigValue(providerIndex, "connections"))
+            ?? StringUtil.EmptyToNull(GetConfigValue("usenet.connections"))
+            ?? StringUtil.EmptyToNull(Environment.GetEnvironmentVariable("MAX_CONNECTIONS"))
+            ?? "10",
+            CultureInfo.InvariantCulture
+        );
+    }
+
+    /// <summary>
+    /// Gets the maximum number of queue connections allowed for API operations. Defaults to 4.
+    /// </summary>
+    public int GetMaxQueueConnections()
+    {
+        return int.Parse(
+            StringUtil.EmptyToNull(GetConfigValue("api.max-queue-connections"))
+            ?? StringUtil.EmptyToNull(Environment.GetEnvironmentVariable("MAX_QUEUE_CONNECTIONS"))
+            ?? "4",
+            CultureInfo.InvariantCulture
         );
     }
 

--- a/backend/Database/Models/ConfigItem.cs
+++ b/backend/Database/Models/ConfigItem.cs
@@ -7,6 +7,7 @@ public class ConfigItem
     public static readonly ImmutableHashSet<string> Keys = ImmutableHashSet.Create([
         "api.key",
         "api.categories",
+        "api.max-queue-connections",
         // Legacy single provider keys (maintained for backward compatibility)
         "usenet.host",
         "usenet.port",


### PR DESCRIPTION
## Summary
- add ConfigManager helpers to parse usenet and queue connection limits
- use centralized GetMaxConnections in UsenetStreamingClient
- expose api.max-queue-connections key

## Testing
- `dotnet build`
- `dotnet build -r win-x64`
- `dotnet test backend/NzbWebDAV.csproj`

------
https://chatgpt.com/codex/tasks/task_b_68aee9194b488321bc25e51b571e679b