### PR TITLE
Reserve connections during queue processing

### DIFF
--- a/backend/Clients/Connections/ReservedConnectionsContext.cs
+++ b/backend/Clients/Connections/ReservedConnectionsContext.cs
@@ -1,0 +1,12 @@
+namespace NzbWebDAV.Clients.Connections;
+
+public sealed class ReservedConnectionsContext
+{
+    public ReservedConnectionsContext(int reservedConnections)
+    {
+        ReservedConnections = reservedConnections;
+    }
+
+    public int ReservedConnections { get; }
+}
+


### PR DESCRIPTION
## Summary
- compute reserved connection count so queue processing leaves room for other operations
- mark queue processing scope with `ReservedConnectionsContext` and propagate to connection pool
- connection pool reads reserved connection context when acquiring locks

## Testing
- `dotnet test backend/NzbWebDAV.csproj`

------
https://chatgpt.com/codex/tasks/task_b_68aeea7520fc8321a9cad819275396e9