### PR TITLE
Use parameterized time for queue filtering

### DIFF
--- a/backend/Database/DavDatabaseClient.cs
+++ b/backend/Database/DavDatabaseClient.cs
@@ -59,13 +59,12 @@ public sealed class DavDatabaseClient(DavDatabaseContext ctx)
     }
 
     // queue
-    public Task<QueueItem?> GetTopQueueItem(CancellationToken ct = default)
+    public Task<QueueItem?> GetTopQueueItem(DateTime nowTime, CancellationToken ct = default)
     {
-        var nowTime = DateTime.Now;
         return Ctx.QueueItems
             .OrderByDescending(q => q.Priority)
             .ThenBy(q => q.CreatedAt)
-            .Where(q => q.PauseUntil == null || DateTime.Now >= q.PauseUntil)
+            .Where(q => q.PauseUntil == null || nowTime >= q.PauseUntil)
             .Skip(0)
             .Take(1)
             .FirstOrDefaultAsync(ct);

--- a/backend/Services/QueueManager.cs
+++ b/backend/Services/QueueManager.cs
@@ -51,7 +51,7 @@ public class QueueManager : IDisposable
                 // get the next queue-item from the database
                 await using var dbContext = new DavDatabaseContext();
                 var dbClient = new DavDatabaseClient(dbContext);
-                var queueItem = await dbClient.GetTopQueueItem(ct);
+                var queueItem = await dbClient.GetTopQueueItem(DateTime.Now, ct);
                 if (queueItem is null)
                 {
                     // if we're done with the queue, wait


### PR DESCRIPTION
## Summary
- Use supplied nowTime parameter when filtering queue items
- Pass current time from QueueManager when retrieving top queue item

## Testing
- `/tmp/dotnet9/dotnet build backend/NzbWebDAV.csproj`

------
https://chatgpt.com/codex/tasks/task_b_68aeec46c1a08321a2016a803d85017d