### PR TITLE
feat: add read-only WebDAV option

### DIFF
--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -187,6 +187,13 @@ public class ConfigManager
         return (configValue != null ? bool.Parse(configValue) : defaultValue);
     }
 
+    public bool IsEnforceReadonlyWebdavEnabled()
+    {
+        var defaultValue = true;
+        var configValue = StringUtil.EmptyToNull(GetConfigValue("webdav.enforce-readonly"));
+        return configValue != null ? bool.Parse(configValue) : defaultValue;
+    }
+
     public class ConfigEventArgs : EventArgs
     {
         public Dictionary<string, string> ChangedConfig { get; set; } = new();

--- a/backend/WebDav/DatabaseStoreCollection.cs
+++ b/backend/WebDav/DatabaseStoreCollection.cs
@@ -63,6 +63,9 @@ public class DatabaseStoreCollection(
 
     protected override async Task<DavStatusCode> DeleteItemAsync(DeleteItemRequest request)
     {
+        if (configManager.IsEnforceReadonlyWebdavEnabled())
+            return DavStatusCode.Forbidden;
+
         // Cannot delete items from dav root.
         if (davDirectory.Id == DavItem.Root.Id)
             return DavStatusCode.Forbidden;
@@ -100,7 +103,7 @@ public class DatabaseStoreCollection(
             DavItem.ItemType.Directory =>
                 new DatabaseStoreCollection(davItem, dbClient, configManager, usenetClient, queueManager),
             DavItem.ItemType.SymlinkRoot =>
-                new DatabaseStoreSymlinkCollection(davItem, dbClient),
+                new DatabaseStoreSymlinkCollection(davItem, dbClient, configManager),
             DavItem.ItemType.NzbFile =>
                 new DatabaseStoreNzbFile(davItem, dbClient, usenetClient, configManager),
             DavItem.ItemType.RarFile =>

--- a/backend/WebDav/DatabaseStoreWatchFolder.cs
+++ b/backend/WebDav/DatabaseStoreWatchFolder.cs
@@ -63,6 +63,9 @@ public class DatabaseStoreWatchFolder(
 
     protected override async Task<DavStatusCode> DeleteItemAsync(DeleteItemRequest request)
     {
+        if (configManager.IsEnforceReadonlyWebdavEnabled())
+            return DavStatusCode.Forbidden;
+
         var controller = new RemoveFromQueueController(null!, dbClient, queueManager, configManager);
 
         // get the item to delete

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -37,6 +37,7 @@ const defaultConfig = {
     "usenet.connections-per-stream": "",
     "webdav.user": "",
     "webdav.pass": "",
+    "webdav.enforce-readonly": "true",
     "rclone.mount-dir": "",
 }
 

--- a/frontend/app/routes/settings/webdav/webdav.tsx
+++ b/frontend/app/routes/settings/webdav/webdav.tsx
@@ -40,6 +40,16 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
                     Use this password to connect to the webdav
                 </Form.Text>
             </Form.Group>
+            <hr />
+            <Form.Group>
+                <Form.Check
+                    type="checkbox"
+                    id="webdav-enforce-readonly-input"
+                    label="Enforce Read-Only"
+                    checked={config["webdav.enforce-readonly"] === "true"}
+                    onChange={e => setNewConfig({ ...config, "webdav.enforce-readonly": e.target.checked.toString() })}
+                />
+            </Form.Group>
         </div>
     );
 }
@@ -47,6 +57,7 @@ export function WebdavSettings({ config, setNewConfig }: SabnzbdSettingsProps) {
 export function isWebdavSettingsUpdated(config: Record<string, string>, newConfig: Record<string, string>) {
     return config["webdav.user"] !== newConfig["webdav.user"]
         || config["webdav.pass"] !== newConfig["webdav.pass"]
+        || config["webdav.enforce-readonly"] !== newConfig["webdav.enforce-readonly"]
 }
 
 export function isWebdavSettingsValid(newConfig: Record<string, string>) {


### PR DESCRIPTION
## Summary
- add `webdav.enforce-readonly` setting with backend enforcement
- expose WebDAV read-only toggle in settings UI

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: missing script "test")*
- `npm run build` *(fails: react-router not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b0612347448321b0620118d5c60a10