### PR TITLE
Handle obfuscated single-file RAR archives

### DIFF
--- a/backend/Services/FileAggregators/RarAggregator.cs
+++ b/backend/Services/FileAggregators/RarAggregator.cs
@@ -1,6 +1,7 @@
 ﻿using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Services.FileProcessors;
+using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Services.FileAggregators;
 
@@ -42,6 +43,13 @@ public class RarAggregator(DavDatabaseClient dbClient, DavItem mountDirectory) :
             var rarParts = archiveFile.Value.ToArray();
             var parentDirectory = EnsurePath(pathWithinArchive);
             var fileName = Path.GetFileName(pathWithinArchive);
+
+            if (archiveFiles.Count == 1 && ObfuscationUtil.IsProbablyObfuscated(fileName))
+            {
+                var extension = Path.GetExtension(fileName);
+                var mountDirName = Path.GetFileNameWithoutExtension(mountDirectory.Name);
+                fileName = mountDirName + extension;
+            }
 
             // Check if file already exists
             var existingItem = dbClient.Ctx.Items


### PR DESCRIPTION
## Summary
- derive meaningful filenames for single-file RAR archives that appear obfuscated
- import utility namespace needed for obfuscation check

## Testing
- `dotnet test backend/NzbWebDAV.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_b_68b18f78a55c83219e86998fcf7a8ec0