### PR TITLE
Add width transition to queue progress bar

### DIFF
--- a/frontend/app/routes/queue/components/queue-table/queue-table.module.css
+++ b/frontend/app/routes/queue/components/queue-table/queue-table.module.css
@@ -86,6 +86,7 @@
     height: 8px !important;
     border-radius: var(--radius-sm) !important;
     background-color: hsl(200 20% 15%) !important;
+    transition: width 500ms ease-in-out;
 }
 
 .progress-text {


### PR DESCRIPTION
## Summary
- animate queue progress bar width changes with a CSS transition

## Testing
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b2d871617483219bd27a84b9f561e6