### PR TITLE
Remove extracted directory prefix from RarAggregator paths

### DIFF
--- a/backend/Services/FileAggregators/RarAggregator.cs
+++ b/backend/Services/FileAggregators/RarAggregator.cs
@@ -83,9 +83,7 @@ public class RarAggregator(DavDatabaseClient dbClient, DavItem mountDirectory) :
     private DavItem EnsurePath(string pathWithinArchive)
     {
         var pathSegments = pathWithinArchive
-            .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-            .Prepend("extracted")
-            .ToArray();
+            .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         var parentDirectory = mountDirectory;
         var pathKey = "";
         for (var i = 0; i < pathSegments.Length - 1; i++)


### PR DESCRIPTION
## Summary
- avoid prepending `extracted` directory when building archive paths in `RarAggregator`

## Testing
- `dotnet test backend.Tests/Backend.Tests.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_b_68b6edcec0e08321b66a4764aca8a42e